### PR TITLE
Fix booking table definition

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/entity/Booking.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/Booking.java
@@ -1,6 +1,12 @@
 package org.teamseven.hms.backend.booking.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +19,7 @@ import org.hibernate.annotations.Where;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.UUID;
 
 @Data
@@ -27,7 +34,7 @@ public class Booking {
     @Id
     @Column(name="booking_id", insertable=false)
     @GeneratedValue
-    private UUID booking_id;
+    private UUID bookingId;
 
     private UUID appointmentId;
 
@@ -54,15 +61,15 @@ public class Booking {
     private Long gst = 8L;
 
     @NotNull
-    private OffsetDateTime startTime;
+    private String slots;
 
     @NotNull
-    private OffsetDateTime endTime;
+    private Date reservedDate;
 
     @NotNull
     private boolean isActive = true;
 
-    @Generated()
+    @Generated
     @Column(name="created_at", insertable=false)
     private OffsetDateTime createdAt;
 

--- a/src/main/resources/db/migration/V10__create_booking_table.sql
+++ b/src/main/resources/db/migration/V10__create_booking_table.sql
@@ -17,6 +17,7 @@ CREATE TABLE bookings(
     FOREIGN KEY (appointment_id) REFERENCES appointments(appointment_id) ON DELETE CASCADE,
     FOREIGN KEY (test_id) REFERENCES tests(test_id) ON DELETE CASCADE,
     FOREIGN KEY (patient_id) REFERENCES patient(patientid) ON DELETE CASCADE,
+    FOREIGN KEY (service_id) REFERENCES services(servicesid) ON DELETE CASCADE,
     INDEX idx_bookings_patient_id (patient_id),
     INDEX idx_bookings_service_reserved_date (service_id, reserved_date)
 );


### PR DESCRIPTION
## Problem
- Previously we story booking / reservation time with `start_time` & `end_time` attributes
- For simplicity, we want to change it to a single attribute `slots` denoting all the slots the customer is receiving.

## Implementation
- Change start time & end time attributes to `reserved_date` and `slots`
- Slots are expected to be comma-delimited for a single booking.
- Modify the index of `bookings` to suit the use cases better