### PR TITLE
Add entity objects for Patient, Doctor, and Service

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/catalog/entity/Service.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/entity/Service.java
@@ -1,0 +1,58 @@
+package org.teamseven.hms.backend.catalog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.*;
+import org.teamseven.hms.backend.user.entity.Doctor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@SQLDelete(sql = "UPDATE services SET is_active = '0' WHERE servicesid=?")
+@Where(clause = "is_active = '1'")
+@Table(name = "services")
+public class Service {
+    @Id
+    @Column(name="servicesid", insertable=false)
+    @GeneratedValue
+    private UUID serviceId;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "doctorid", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Doctor doctorId;
+
+    private String type;
+
+    private String name;
+
+    private String description;
+
+    private String duration;
+
+    private Double estimatedPrice;
+
+    @Column(insertable=false)
+    private Integer isActive = 1;
+
+    @Generated()
+    @Column(name="created_at", insertable=false)
+    private OffsetDateTime createdAt;
+
+    private OffsetDateTime modifiedAt;
+}

--- a/src/main/java/org/teamseven/hms/backend/user/entity/Doctor.java
+++ b/src/main/java/org/teamseven/hms/backend/user/entity/Doctor.java
@@ -1,0 +1,50 @@
+package org.teamseven.hms.backend.user.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@SQLDelete(sql = "UPDATE doctor SET is_active = 0 WHERE servicesid=?")
+@Where(clause = "is_active = 1")
+@Table(name = "doctor")
+public class Doctor {
+    @Id
+    @Column(name="doctorid", insertable=false)
+    @GeneratedValue
+    private UUID doctorId;
+
+    @Column(name = "userid")
+    private String userId;
+
+    private String speciality;
+
+    @Column(name = "consultationfees")
+    private Double consultationFees;
+
+    @Column(name = "yearsofexp")
+    private Integer yearsOfExperience;
+
+    @NotNull
+    @Column(insertable=false)
+    private Integer isActive = 1;
+
+    @Generated()
+    @Column(name="created_at", insertable=false)
+    private OffsetDateTime createdAt;
+
+    private OffsetDateTime modifiedAt;
+}

--- a/src/main/java/org/teamseven/hms/backend/user/entity/DoctorRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/user/entity/DoctorRepository.java
@@ -1,0 +1,8 @@
+package org.teamseven.hms.backend.user.entity;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+public interface DoctorRepository extends CrudRepository<Doctor, UUID> {
+}

--- a/src/main/java/org/teamseven/hms/backend/user/entity/Patient.java
+++ b/src/main/java/org/teamseven/hms/backend/user/entity/Patient.java
@@ -1,0 +1,46 @@
+package org.teamseven.hms.backend.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@SQLDelete(sql = "UPDATE patient SET is_active = 0 WHERE patientid=?")
+@Where(clause = "is_active = 1")
+@Table(name = "patient")
+public class Patient {
+    @Id
+    @Column(name="patientid", insertable=false)
+    @GeneratedValue
+    private UUID patientId;
+
+    @Column(name = "userid")
+    private String userId;
+
+    @Column(name = "bloodgroup")
+    private String bloodGroup;
+
+    @Column(name = "medicalcondition")
+    private String medicalCondition;
+
+    @Column(insertable=false)
+    private Integer isActive = 1;
+
+    @Generated
+    @Column(name="created_at", insertable=false)
+    private OffsetDateTime createdAt;
+
+    private OffsetDateTime modifiedAt;
+}

--- a/src/main/java/org/teamseven/hms/backend/user/entity/PatientRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/user/entity/PatientRepository.java
@@ -1,0 +1,8 @@
+package org.teamseven.hms.backend.user.entity;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+public interface PatientRepository extends CrudRepository<Patient, UUID> {
+}

--- a/src/main/resources/db/migration/V12__drop_not_null_doctorId_services.sql
+++ b/src/main/resources/db/migration/V12__drop_not_null_doctorId_services.sql
@@ -1,0 +1,1 @@
+ALTER TABLE services MODIFY doctorid binary(16);


### PR DESCRIPTION
## Feature / Problem
- PR raised as part of unblocking https://group07swe5006.atlassian.net/browse/HEAL-40 & https://group07swe5006.atlassian.net/browse/HEAL-41
- We already have the database definitions for patients, doctors, and services.
- However, currently the entity objects for those tables haven't been defined such that using JPA for join queries to the tables is still not possible.
- We've also found that initially we imposed a not null restriction on doctor_id under services table, which isn't true to the use cases where doctor_id should be null for test services.

## Implementation / Solution
- Add entities & repository classes for said tables
- Drop not null constraint on doctor_id column