### PR TITLE
Add view tests catalog feature

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/dto/BookingOverview.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/BookingOverview.java
@@ -1,5 +1,6 @@
 package org.teamseven.hms.backend.booking.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,5 +18,5 @@ public class BookingOverview {
     private String[] slots;
     private BookingType type;
     private String bookingDescription;
-    private Date bookingDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") private Date bookingDate;
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
@@ -12,7 +12,7 @@ public interface BookingRepository extends CrudRepository<Booking, UUID> {
     @Query(
             value = "SELECT * " +
                     "from bookings where patient_id = UUID_TO_BIN(:patientId) " +
-                    "ORDER BY reserved_date, created_at DESC",
+                    "ORDER BY reserved_date desc, created_at DESC",
             nativeQuery=true
     )
     Page<Booking> findPatientBookingsWithPagination(

--- a/src/main/java/org/teamseven/hms/backend/catalog/controller/CatalogController.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/controller/CatalogController.java
@@ -1,0 +1,28 @@
+package org.teamseven.hms.backend.catalog.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.teamseven.hms.backend.catalog.entity.ServiceType;
+import org.teamseven.hms.backend.catalog.service.CatalogService;
+import org.teamseven.hms.backend.shared.ResponseWrapper;
+
+@RestController
+@RequestMapping("/api/v1/available-services/")
+public class CatalogController {
+    @Autowired private CatalogService catalogService;
+
+    @GetMapping(value = "lab-tests")
+    public ResponseEntity<ResponseWrapper> getTestServices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        return ResponseEntity
+                .ok()
+                .body(
+                        new ResponseWrapper.Success<>(
+                                catalogService.getServiceCatalog(ServiceType.TEST, page, pageSize)
+                        )
+                );
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/catalog/dto/ServiceCatalogItem.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/dto/ServiceCatalogItem.java
@@ -1,0 +1,22 @@
+package org.teamseven.hms.backend.catalog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.teamseven.hms.backend.catalog.entity.ServiceType;
+
+import java.util.UUID;
+
+public sealed class ServiceCatalogItem {
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static final class Test extends ServiceCatalogItem {
+        private String name;
+        private String description;
+        private UUID serviceId;
+        private ServiceType type = ServiceType.TEST;
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/catalog/dto/ServiceCatalogPaginationResponse.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/dto/ServiceCatalogPaginationResponse.java
@@ -1,0 +1,19 @@
+package org.teamseven.hms.backend.catalog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ServiceCatalogPaginationResponse {
+    private long totalElements;
+    private int currentPage;
+
+    private List<ServiceCatalogItem> items;
+}

--- a/src/main/java/org/teamseven/hms/backend/catalog/entity/Service.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/entity/Service.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Entity
 @SQLDelete(sql = "UPDATE services SET is_active = '0' WHERE servicesid=?")
-@Where(clause = "is_active = '1'")
+@Where(clause = "is_active = 1")
 @Table(name = "services")
 public class Service {
     @Id

--- a/src/main/java/org/teamseven/hms/backend/catalog/entity/ServiceRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/entity/ServiceRepository.java
@@ -1,8 +1,22 @@
 package org.teamseven.hms.backend.catalog.entity;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
 public interface ServiceRepository extends CrudRepository<Service, UUID> {
+    @Query(
+            value = "SELECT *" +
+                    "from services where type = :serviceType " +
+                    "ORDER BY name",
+            nativeQuery=true
+    )
+    Page<Service> findAvailableServices(
+            @Param("serviceType") String serviceType,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/teamseven/hms/backend/catalog/entity/ServiceType.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/entity/ServiceType.java
@@ -1,0 +1,6 @@
+package org.teamseven.hms.backend.catalog.entity;
+
+public enum ServiceType {
+    APPOINTMENT,
+    TEST
+}

--- a/src/main/java/org/teamseven/hms/backend/catalog/service/CatalogService.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/service/CatalogService.java
@@ -1,10 +1,17 @@
 package org.teamseven.hms.backend.catalog.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.teamseven.hms.backend.booking.dto.BookingPaginationResponse;
+import org.teamseven.hms.backend.catalog.dto.ServiceCatalogItem;
+import org.teamseven.hms.backend.catalog.dto.ServiceCatalogPaginationResponse;
 import org.teamseven.hms.backend.catalog.dto.ServiceOverview;
 import org.teamseven.hms.backend.catalog.entity.ServiceRepository;
+import org.teamseven.hms.backend.catalog.entity.ServiceType;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.function.Function;
@@ -12,7 +19,7 @@ import java.util.function.Function;
 @Service
 public class CatalogService {
     @Autowired
-    ServiceRepository repository;
+    private ServiceRepository repository;
 
     public ServiceOverview getServiceOverview(UUID serviceId) {
         org.teamseven.hms.backend.catalog.entity.Service service = repository.findById(serviceId)
@@ -31,4 +38,40 @@ public class CatalogService {
                     .description(it.getDescription())
                     .estimatedPrice(it.getEstimatedPrice())
                     .build();
+
+
+    public ServiceCatalogPaginationResponse getServiceCatalog(
+            ServiceType serviceType,
+            int page,
+            int pageSize
+    ) {
+        int zeroBasedIndexPage = page - 1;
+
+        Page<org.teamseven.hms.backend.catalog.entity.Service> services
+                = repository.findAvailableServices(
+                        serviceType.toString(),
+                Pageable.ofSize(pageSize).withPage(zeroBasedIndexPage)
+        );
+
+        List<ServiceCatalogItem> items =  switch (serviceType) {
+            case TEST -> services.map(getTestCatalogItem).toList();
+            default -> List.of();
+        };
+
+        return ServiceCatalogPaginationResponse.builder()
+                .items(items)
+                .totalElements(services.getTotalElements())
+                .currentPage(page)
+                .build();
+    }
+
+    private final Function<
+            org.teamseven.hms.backend.catalog.entity.Service,
+            ServiceCatalogItem
+    > getTestCatalogItem = it -> ServiceCatalogItem.Test.builder()
+            .name(it.getName())
+            .description(it.getDescription())
+            .serviceId(it.getServiceId())
+            .type(ServiceType.TEST)
+            .build();
 }

--- a/src/test/java/org/teamseven/hms/backend/catalog/controller/CatalogControllerTest.java
+++ b/src/test/java/org/teamseven/hms/backend/catalog/controller/CatalogControllerTest.java
@@ -1,0 +1,84 @@
+package org.teamseven.hms.backend.catalog.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.teamseven.hms.backend.catalog.dto.ServiceCatalogPaginationResponse;
+import org.teamseven.hms.backend.catalog.entity.ServiceType;
+import org.teamseven.hms.backend.catalog.service.CatalogService;
+import org.teamseven.hms.backend.shared.ResponseWrapper;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class CatalogControllerTest {
+    @Mock
+    private CatalogService catalogService;
+
+    @InjectMocks
+    private CatalogController controller;
+
+    private MockMvc mockMvc;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        this.mockMvc =  MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    public void testGetTestsCatalog_paginationNotSpecified_assertPaginationUseDefault() throws Exception {
+        ServiceCatalogPaginationResponse response = getMockResponse();
+        ResponseWrapper.Success<ServiceCatalogPaginationResponse> expectedResponse = new ResponseWrapper.Success<>(
+                response
+        );
+
+        when(catalogService.getServiceCatalog(any(), any(int.class), any(int.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/available-services/lab-tests"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+
+        verify(catalogService).getServiceCatalog(ServiceType.TEST, 1, 10);
+    }
+
+    @Test
+    public void testGetTestsCatalog_paginationCustomised_assertPaginationAsRequested() throws Exception {
+        ServiceCatalogPaginationResponse response = getMockResponse();
+        ResponseWrapper.Success<ServiceCatalogPaginationResponse> expectedResponse = new ResponseWrapper.Success<>(
+                response
+        );
+
+        when(catalogService.getServiceCatalog(any(), any(int.class), any(int.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/available-services/lab-tests?page=2&pageSize=5"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+
+        verify(catalogService).getServiceCatalog(ServiceType.TEST, 2, 5);
+    }
+
+    private ServiceCatalogPaginationResponse getMockResponse() {
+        return ServiceCatalogPaginationResponse.builder()
+                .currentPage(1)
+                .totalElements(1)
+                .items(List.of())
+                .build();
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/catalog/service/CatalogServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/catalog/service/CatalogServiceTest.java
@@ -5,17 +5,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.teamseven.hms.backend.catalog.dto.ServiceCatalogPaginationResponse;
 import org.teamseven.hms.backend.catalog.dto.ServiceOverview;
 import org.teamseven.hms.backend.catalog.entity.Service;
 import org.teamseven.hms.backend.catalog.entity.ServiceRepository;
-
+import org.teamseven.hms.backend.catalog.entity.ServiceType;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -64,5 +68,31 @@ public class CatalogServiceTest {
         assertEquals(mockServiceObject.getType(), overview.getType());
         assertEquals(mockServiceObject.getName(), overview.getName());
         assertEquals(mockServiceObject.getDescription(), overview.getDescription());
+    }
+
+    @Test
+    public void testGetAvailableServices_returnFormattedDataFromRepository() {
+        List<Service> mockList = getMockServiceList();
+
+        when(serviceRepository.findAvailableServices(any(), any()))
+                .thenReturn(
+                        new PageImpl(mockList, PageRequest.of(0, 10), 1L)
+                );
+
+        ServiceCatalogPaginationResponse response = catalogService.getServiceCatalog(ServiceType.TEST, 1, 10);
+        verify(serviceRepository).findAvailableServices(eq("TEST"), any());
+
+        assertEquals(1, response.getTotalElements());
+        assertEquals(1, response.getCurrentPage());
+    }
+
+    private List<Service> getMockServiceList() {
+        return List.of(
+                Service.builder()
+                        .serviceId(UUID.randomUUID())
+                        .name("test name")
+                        .description("test description")
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
## Feature / Problem
- Changes on this PR add the endpoint `/api/v1/available-services/lab-tests?page={number default 1}&pageSize={number default 10}` for viewing test services
- Additionally during testing we also found that the query implemented for booking pagination is buggy, with which the ordering of the items isn't in a reverse chronological order, so we added the fix for that in this PR.
- Fix date formatting for booking history response
- Add unit tests