### PR TITLE
Parameterize security filter chain based on env

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/config/SecurityEnvConfig.java
+++ b/src/main/java/org/teamseven/hms/backend/config/SecurityEnvConfig.java
@@ -1,0 +1,10 @@
+package org.teamseven.hms.backend.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "sec-env-conf", ignoreUnknownFields = false)
+public class SecurityEnvConfig {
+    private boolean enableLoginGuard = false;
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -18,3 +18,6 @@ spring:
     user: healmaster
     password: healgroup7
     baselineOnMigrate: true
+
+secEnvConf:
+  enableLoginGuard: false

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,4 +1,5 @@
 spring:
+  address: localhost
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,2 +1,5 @@
 server:
   port: 8080
+
+sec-env-conf:
+  enable-login-guard: true

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -8,3 +8,6 @@ spring:
     password:
   flyway:
     enabled: false
+
+secEnvConf:
+  enableLoginGuard: false


### PR DESCRIPTION
Allow changing application properties to bypass login for testing purposes.
By default, the application properties will still enforce such security filtering to ensure that live endpoints are safely guarded