### PR TITLE
Add endpoint to fetch slots for a service on a day

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/dto/ServiceSlotInfo.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/ServiceSlotInfo.java
@@ -1,0 +1,17 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ServiceSlotInfo {
+    private Set<Integer> bookedSlots;
+    private Set<Integer> availableSlots;
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -41,4 +43,6 @@ public interface BookingRepository extends CrudRepository<Booking, UUID> {
             nativeQuery=true
     )
     Optional<Booking> findByBookingId(String bookingId);
+
+    List<Booking> findByServiceIdAndReservedDate(UUID serviceId, String reservedDate);
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/service/SlotCheckerService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/SlotCheckerService.java
@@ -1,0 +1,55 @@
+package org.teamseven.hms.backend.booking.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.teamseven.hms.backend.booking.dto.ServiceSlotInfo;
+import org.teamseven.hms.backend.booking.entity.Booking;
+import org.teamseven.hms.backend.booking.entity.BookingRepository;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+public class SlotCheckerService {
+    @Autowired
+    private BookingRepository repository;
+
+    private static final int FIRST_SLOT_NUM = 1;
+    private static final int LAST_SLOT_NUM = 16;
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+
+    public ServiceSlotInfo getServiceSlots(
+            UUID serviceId,
+            Date reservedDate
+    ) {
+        Logger.getAnonymousLogger().info(
+                "beginning query. service id: "
+                + serviceId + "reserved date: " + new SimpleDateFormat(DATE_FORMAT).format(reservedDate)
+        );
+        List<Booking> existingBookings = repository.findByServiceIdAndReservedDate(
+                serviceId,
+                new SimpleDateFormat(DATE_FORMAT).format(reservedDate)
+        );
+
+        Set<Integer> bookedSlots = existingBookings.stream()
+                .map(it -> Integer.parseInt(it.getSlots()))
+                .collect(Collectors.toSet());
+
+        Set<Integer> availableSlots = IntStream.range(FIRST_SLOT_NUM, LAST_SLOT_NUM + 1)
+                .boxed()
+                .collect(Collectors.filtering(it -> !bookedSlots.contains(it), Collectors.toSet()));
+
+        return ServiceSlotInfo
+                .builder()
+                .bookedSlots(bookedSlots)
+                .availableSlots(availableSlots)
+                .build();
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/booking/service/SlotCheckerServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/service/SlotCheckerServiceTest.java
@@ -1,0 +1,56 @@
+package org.teamseven.hms.backend.booking.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.teamseven.hms.backend.booking.dto.ServiceSlotInfo;
+import org.teamseven.hms.backend.booking.entity.Booking;
+import org.teamseven.hms.backend.booking.entity.BookingRepository;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SlotCheckerServiceTest {
+    @Mock
+    private BookingRepository repository;
+
+    @InjectMocks
+    private SlotCheckerService service;
+
+    @Test
+    public void testGetServiceSlots_givenSomeBookedSlots_deriveAvailableSlots() throws ParseException {
+        when(repository.findByServiceIdAndReservedDate(any(), any()))
+                .thenReturn(
+                        List.of(
+                                Booking.builder()
+                                        .slots("1").build(),
+                                Booking.builder()
+                                        .slots("2").build(),
+                                Booking.builder()
+                                        .slots("8").build()
+                        )
+                );
+
+        UUID mockUuid = UUID.randomUUID();
+        Date reservedDate = new SimpleDateFormat("yyyy-MM-dd").parse("2023-10-11");
+
+        ServiceSlotInfo slotInfo = service.getServiceSlots(mockUuid, reservedDate);
+
+        verify(repository).findByServiceIdAndReservedDate(mockUuid, "2023-10-11");
+
+        assertEquals(Set.of(1, 2, 8), slotInfo.getBookedSlots());
+        assertEquals(Set.of(3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16), slotInfo.getAvailableSlots());
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -10,4 +10,4 @@ spring:
     enabled: false
 
 secEnvConf:
-  enableLoginGuard: false
+  enableLoginGuard: true


### PR DESCRIPTION
- Booking of appointments should be created at a unique time slot for one doctor on a day.
- Currently we don't have the capability for patients to choose & see the available slots at which they can have their appointment.
- Changes on this PR add a new endpoint `/api/v1/services/bookings/{service-id}/schedules?date=yyyy-MM-dd` to fetch the available slots of a service id on a given day.
- Endpoint will return a set of booked slots and of available slots.