### PR TITLE
Add patient details on get booking details endpoint

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/dto/BookingDetails.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/BookingDetails.java
@@ -16,6 +16,7 @@ public sealed class BookingDetails {
 
         private String testResult;
         private String testId;
+        private String testStatus;
     }
 
     @Data

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/BookingInfoResponse.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/BookingInfoResponse.java
@@ -16,4 +16,5 @@ public class BookingInfoResponse {
     private String bookingDate;
     private String[] slots;
     private BookingDetails details;
+    private PatientDataBookingDetails patientDetails;
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/PatientDataBookingDetails.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/PatientDataBookingDetails.java
@@ -1,0 +1,16 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class PatientDataBookingDetails {
+    private String patientName;
+    private String dateOfBirth;
+    private String gender;
+}

--- a/src/main/java/org/teamseven/hms/backend/user/dto/PatientProfileOverview.java
+++ b/src/main/java/org/teamseven/hms/backend/user/dto/PatientProfileOverview.java
@@ -1,0 +1,19 @@
+package org.teamseven.hms.backend.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PatientProfileOverview {
+    private String patientName;
+    private String gender;
+    private String dateOfBirth;
+}

--- a/src/main/java/org/teamseven/hms/backend/user/service/PatientService.java
+++ b/src/main/java/org/teamseven/hms/backend/user/service/PatientService.java
@@ -1,0 +1,28 @@
+package org.teamseven.hms.backend.user.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.teamseven.hms.backend.user.User;
+import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
+import org.teamseven.hms.backend.user.entity.Patient;
+import org.teamseven.hms.backend.user.entity.PatientRepository;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class PatientService {
+    @Autowired
+    private PatientRepository repository;
+
+
+    public PatientProfileOverview getPatientProfile(UUID patientId) {
+        Patient patient = repository.findById(patientId).orElseThrow(NoSuchElementException::new);
+        User user = patient.getUser();
+        return PatientProfileOverview.builder()
+                .patientName(user.getName())
+                .gender(user.getGender())
+                .dateOfBirth(user.getDateOfBirth())
+                .build();
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/booking/service/BookingServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/service/BookingServiceTest.java
@@ -11,14 +11,16 @@ import org.teamseven.hms.backend.booking.dto.*;
 import org.teamseven.hms.backend.booking.entity.Appointment;
 import org.teamseven.hms.backend.booking.entity.Booking;
 import org.teamseven.hms.backend.booking.entity.BookingRepository;
+import org.teamseven.hms.backend.booking.entity.TestStatus;
 import org.teamseven.hms.backend.catalog.dto.ServiceOverview;
 import org.teamseven.hms.backend.catalog.service.CatalogService;
 import org.teamseven.hms.backend.user.User;
+import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
 import org.teamseven.hms.backend.user.entity.Patient;
 import org.teamseven.hms.backend.user.entity.PatientRepository;
+import org.teamseven.hms.backend.user.service.PatientService;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -39,6 +41,9 @@ public class BookingServiceTest {
 
     @Mock
     private CatalogService catalogService;
+
+    @Mock
+    private PatientService patientService;
 
     @InjectMocks
     private BookingService bookingService;
@@ -78,6 +83,7 @@ public class BookingServiceTest {
                         ServiceOverview.builder()
                                 .serviceId(UUID.randomUUID())
                                 .name("Loki")
+                                .type("APPOINTMENT")
                                 .description("test description")
                                 .build()
                 );
@@ -127,11 +133,21 @@ public class BookingServiceTest {
         when(bookingRepository.findById(any())).
                 thenReturn(Optional.of(getAppointmentBooking()));
 
+        when(patientService.getPatientProfile(any()))
+                .thenReturn(
+                        PatientProfileOverview.builder()
+                                .patientName("John Doe")
+                                .gender("M")
+                                .dateOfBirth("1990-01-01")
+                                .build()
+                );
+
         when(catalogService.getServiceOverview(any()))
                 .thenReturn(
                         ServiceOverview.builder()
                                 .name("Dr. Loki")
                                 .description("Dermatology")
+                                .type("APPOINTMENT")
                                 .build()
                 );
 
@@ -154,7 +170,21 @@ public class BookingServiceTest {
                 thenReturn(Optional.of(getTestBooking()));
 
         when(catalogService.getServiceOverview(any()))
-                .thenReturn(ServiceOverview.builder().name("Lab test").build());
+                .thenReturn(
+                        ServiceOverview.builder()
+                                .name("Lab test")
+                                .type("TEST")
+                                .build()
+                );
+
+        when(patientService.getPatientProfile(any()))
+                .thenReturn(
+                        PatientProfileOverview.builder()
+                                .patientName("John Doe")
+                                .gender("M")
+                                .dateOfBirth("1990-01-01")
+                                .build()
+                );
 
         UUID uuid = UUID.randomUUID();
 
@@ -173,6 +203,7 @@ public class BookingServiceTest {
                 .test(
                         org.teamseven.hms.backend.booking.entity.Test.builder()
                         .testReport("report")
+                                .status(TestStatus.PENDING)
                         .testId(UUID.randomUUID())
                         .build()
                 )


### PR DESCRIPTION
- Previously we didn't add patient details to be returned on get booking details endpoint.
- After checking the figma design, it seems like for support staff, & doctor view, patient details will be required to be shown when the actor clicks to view booking details.

Solution
- Add the details such as name, gender, and date of birth to be returned on get booking details