### PR TITLE
Enable appointment diagnosis & status update

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/AppointmentUpdateAccessAspect.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/AppointmentUpdateAccessAspect.java
@@ -1,0 +1,49 @@
+package org.teamseven.hms.backend.booking.annotation;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.assertj.core.util.VisibleForTesting;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.teamseven.hms.backend.config.JwtService;
+import org.teamseven.hms.backend.shared.exception.UnauthorizedAccessException;
+import org.teamseven.hms.backend.user.Role;
+
+@Aspect
+@Component
+public class AppointmentUpdateAccessAspect {
+    @Autowired
+    private JwtService jwtService;
+
+    @VisibleForTesting
+    @Around("@annotation(appointmentUpdateAccessValidated)")
+    protected Object validateAccessAllowed(
+            ProceedingJoinPoint pjp,
+            AppointmentUpdateAccessValidated appointmentUpdateAccessValidated
+    ) throws Throwable{
+        HttpServletRequest request = (
+                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()
+        ).getRequest();
+        String jwtToken = getJwtToken(request);
+        Claims jwtClaims = jwtService.extractAllClaims(jwtToken);
+        Role role = Role.valueOf(jwtClaims.get("ROLE", String.class));
+
+        if (role == Role.DOCTOR) {
+            return pjp.proceed();
+        }
+        throw new UnauthorizedAccessException();
+    }
+
+    private String getJwtToken(HttpServletRequest request) {
+        try {
+            return request.getHeader("Authorization").substring(7);
+        } catch (Exception e) {
+            throw new UnauthorizedAccessException();
+        }
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/AppointmentUpdateAccessValidated.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/AppointmentUpdateAccessValidated.java
@@ -1,0 +1,11 @@
+package org.teamseven.hms.backend.booking.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AppointmentUpdateAccessValidated {
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/controller/AppointmentController.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/controller/AppointmentController.java
@@ -1,0 +1,34 @@
+package org.teamseven.hms.backend.booking.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.teamseven.hms.backend.booking.annotation.AppointmentUpdateAccessValidated;
+import org.teamseven.hms.backend.booking.dto.UpdateAppointmentRequest;
+import org.teamseven.hms.backend.booking.service.AppointmentService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/appointments/")
+public class AppointmentController {
+    @Autowired
+    private AppointmentService appointmentService;
+
+    @AppointmentUpdateAccessValidated
+    @PatchMapping("{appointmentId}")
+    public ResponseEntity updateAppointments(
+            @RequestBody UpdateAppointmentRequest updateAppointmentRequest,
+            @PathVariable UUID appointmentId
+    ) {
+        boolean isUpdateSuccesful = appointmentService.updateAppointmentDetails(
+                appointmentId,
+                updateAppointmentRequest
+        );
+
+        return ResponseEntity
+                .status(isUpdateSuccesful? HttpStatus.NO_CONTENT : HttpStatus.NOT_MODIFIED)
+                .build();
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/BookingDetails.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/BookingDetails.java
@@ -29,5 +29,6 @@ public sealed class BookingDetails {
 
         private String comments;
         private String appointmentId;
+        private String appointmentStatus;
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateAppointmentRequest.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateAppointmentRequest.java
@@ -1,0 +1,14 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.*;
+import org.teamseven.hms.backend.booking.entity.AppointmentStatus;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class UpdateAppointmentRequest {
+    private String comments;
+    private AppointmentStatus status;
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/Appointment.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/Appointment.java
@@ -34,6 +34,9 @@ public class Appointment {
 
     private String prescription;
 
+    @Enumerated(EnumType.STRING)
+    private AppointmentStatus status = AppointmentStatus.PENDING;
+
     @NotNull
     private boolean isActive = true;
 

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/AppointmentRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/AppointmentRepository.java
@@ -1,8 +1,21 @@
 package org.teamseven.hms.backend.booking.entity;
 
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.UUID;
 
 public interface AppointmentRepository extends CrudRepository<Appointment, UUID> {
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(
+            "update Appointment a set " +
+            "a.status = :status, " +
+            "a.diagnosis = :comments " +
+            "where a.appointmentId = :appointmentId"
+    )
+    int setStatusAndCommentsForAppointment(AppointmentStatus status, String comments, UUID appointmentId);
+
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/AppointmentStatus.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/AppointmentStatus.java
@@ -1,0 +1,6 @@
+package org.teamseven.hms.backend.booking.entity;
+
+public enum AppointmentStatus {
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/service/AppointmentService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/AppointmentService.java
@@ -1,0 +1,24 @@
+package org.teamseven.hms.backend.booking.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.teamseven.hms.backend.booking.dto.UpdateAppointmentRequest;
+import org.teamseven.hms.backend.booking.entity.AppointmentRepository;
+
+import java.util.UUID;
+
+@Service
+public class AppointmentService {
+    @Autowired private AppointmentRepository repository;
+
+    public boolean updateAppointmentDetails(
+            UUID appointmentId,
+            UpdateAppointmentRequest appointmentRequest
+    ) {
+        return repository.setStatusAndCommentsForAppointment(
+                appointmentRequest.getStatus(),
+                appointmentRequest.getComments(),
+                appointmentId
+        ) == 1;
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/service/BookingService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/BookingService.java
@@ -144,6 +144,7 @@ public class BookingService {
                         .doctorName(serviceOverview.getName())
                         .department(serviceOverview.getDescription())
                         .comments(appointment.getDiagnosis())
+                        .appointmentStatus(appointment.getStatus().toString())
                         .appointmentId(appointment.getAppointmentId().toString())
                         .build();
             }

--- a/src/main/resources/db/migration/V17__alter_appointments_add_status.sql
+++ b/src/main/resources/db/migration/V17__alter_appointments_add_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE appointments
+    ADD COLUMN status VARCHAR(20) DEFAULT 'PENDING';

--- a/src/test/java/org/teamseven/hms/backend/booking/annotation/AppointmentUpdateAspectTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/annotation/AppointmentUpdateAspectTest.java
@@ -1,0 +1,99 @@
+package org.teamseven.hms.backend.booking.annotation;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.teamseven.hms.backend.config.JwtService;
+import org.teamseven.hms.backend.shared.exception.UnauthorizedAccessException;
+import org.teamseven.hms.backend.user.Role;
+
+import java.security.Key;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AppointmentUpdateAspectTest {
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    AppointmentUpdateAccessAspect aspect;
+
+    @BeforeEach
+    public void setUp() {
+        Mockito.reset(jwtService);
+    }
+
+    @Test
+    public void testValidateAccessAllowed_userIsDoctor_assertNotThrowUnauthorized() {
+        ProceedingJoinPoint proceedingJoinPoint = mock();
+        AppointmentUpdateAccessValidated mockAnnotation = mock();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        request.addHeader("Authorization", "Bearer mock token");
+
+        when(jwtService.extractAllClaims(any()))
+                .thenReturn(
+                        getMockClaims(Role.DOCTOR, UUID.randomUUID().toString())
+                );
+
+        assertDoesNotThrow(
+                () -> { aspect.validateAccessAllowed(proceedingJoinPoint, mockAnnotation); }
+        );
+    }
+
+    @Test
+    public void testValidateAccessAllowed_userIsNotDoctor_assertThrowUnauthorized() {
+        ProceedingJoinPoint proceedingJoinPoint = mock();
+        AppointmentUpdateAccessValidated mockAnnotation = mock();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        request.addHeader("Authorization", "Bearer mock token");
+
+        when(jwtService.extractAllClaims(any()))
+                .thenReturn(
+                        getMockClaims(Role.LAB_SUPPORT_STAFF, UUID.randomUUID().toString())
+                );
+
+        assertThrows(
+                UnauthorizedAccessException.class,
+                () -> { aspect.validateAccessAllowed(proceedingJoinPoint, mockAnnotation); }
+        );
+    }
+
+    private Claims getMockClaims(
+            Role role,
+            String roleId
+    ) {
+        byte[] randomKeyBytes = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".getBytes();
+        Key mockKey = Keys.hmacShaKeyFor(randomKeyBytes);
+        String jwt = Jwts.builder()
+                .setClaims(Map.of("ROLE", role, "roleId", roleId))
+                .signWith(mockKey, SignatureAlgorithm.HS256)
+                .compact();
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(mockKey)
+                .build()
+                .parseClaimsJws(jwt)
+                .getBody();
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/booking/controller/AppointmentControllerTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/controller/AppointmentControllerTest.java
@@ -1,0 +1,70 @@
+package org.teamseven.hms.backend.booking.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.teamseven.hms.backend.booking.dto.UpdateAppointmentRequest;
+import org.teamseven.hms.backend.booking.entity.AppointmentStatus;
+import org.teamseven.hms.backend.booking.service.AppointmentService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class AppointmentControllerTest {
+    @Mock
+    private AppointmentService service;
+
+    @InjectMocks
+    private AppointmentController controller;
+
+    private MockMvc mockMvc;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        this.mockMvc =  MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    public void testUpdateAppointment_successfulUpdate_assertReturn204() throws Exception{
+        UpdateAppointmentRequest request = new UpdateAppointmentRequest(
+                "abc",
+                AppointmentStatus.PENDING
+        );
+
+        when(service.updateAppointmentDetails(any(), any())).thenReturn(true);
+
+        mockMvc.perform(
+                patch("/api/v1/appointments/07fec0a8-7145-11ee-8684-0242ac130003")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        ).andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void testUpdateAppointment_unsuccessfulUpdate_assertReturn304() throws Exception{
+        UpdateAppointmentRequest request = new UpdateAppointmentRequest(
+                "abc",
+                AppointmentStatus.PENDING
+        );
+
+        when(service.updateAppointmentDetails(any(), any())).thenReturn(false);
+
+        mockMvc.perform(
+                patch("/api/v1/appointments/07fec0a8-7145-11ee-8684-0242ac130003")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        ).andExpect(status().isNotModified());
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/booking/service/BookingServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/service/BookingServiceTest.java
@@ -8,10 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.teamseven.hms.backend.booking.dto.*;
-import org.teamseven.hms.backend.booking.entity.Appointment;
-import org.teamseven.hms.backend.booking.entity.Booking;
-import org.teamseven.hms.backend.booking.entity.BookingRepository;
-import org.teamseven.hms.backend.booking.entity.TestStatus;
+import org.teamseven.hms.backend.booking.entity.*;
 import org.teamseven.hms.backend.catalog.dto.ServiceOverview;
 import org.teamseven.hms.backend.catalog.service.CatalogService;
 import org.teamseven.hms.backend.user.User;
@@ -106,7 +103,13 @@ public class BookingServiceTest {
 
     private Booking getAppointmentBooking() throws ParseException {
         return Booking.builder()
-                .appointment(Appointment.builder().diagnosis("test").appointmentId(UUID.randomUUID()).build())
+                .appointment(
+                        Appointment.builder()
+                                .status(AppointmentStatus.PENDING)
+                                .diagnosis("test").
+                                appointmentId(UUID.randomUUID())
+                                .build()
+                )
                 .slots("1,2")
                 .bookingId(UUID.fromString("efb5f4bf-75e3-49a5-8785-bb82b70029ed"))
                 .serviceId(UUID.fromString("c4dcd184-ae0b-4cd9-bd91-22ff4ce71321"))


### PR DESCRIPTION
Add a new endpoint to update appointment diagnosis & status
Restrict access for updates only to doctors
add appointment status column in appointments table
Additionally, also return appointment status during booking details view to connect the details view and update flow