### PR TITLE
Allow Lab support staff to update test status & result

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAccessValidated.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAccessValidated.java
@@ -1,0 +1,12 @@
+package org.teamseven.hms.backend.booking.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LabTestStatusUpdateAccessValidated {
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAspect.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAspect.java
@@ -1,0 +1,50 @@
+package org.teamseven.hms.backend.booking.annotation;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.assertj.core.util.VisibleForTesting;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.teamseven.hms.backend.config.JwtService;
+import org.teamseven.hms.backend.shared.exception.UnauthorizedAccessException;
+import org.teamseven.hms.backend.user.Role;
+
+import java.util.logging.Logger;
+
+@Aspect
+@Component
+public class LabTestStatusUpdateAspect {
+    @Autowired private JwtService jwtService;
+
+    @VisibleForTesting
+    @Around("@annotation(labTestUpdateAccessValidated)")
+    protected Object validateAccessAllowed(
+            ProceedingJoinPoint pjp,
+            LabTestStatusUpdateAccessValidated labTestUpdateAccessValidated
+    ) throws Throwable {
+        HttpServletRequest request = (
+                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()
+        ).getRequest();
+        String jwtToken = getJwtToken(request);
+        Claims jwtClaims = jwtService.extractAllClaims(jwtToken);
+        Role role = Role.valueOf(jwtClaims.get("ROLE", String.class));
+
+        if (role == Role.LAB_SUPPORT_STAFF) {
+            return pjp.proceed();
+        }
+        throw new UnauthorizedAccessException();
+    }
+
+    private String getJwtToken(HttpServletRequest request) {
+        try {
+            return request.getHeader("Authorization").substring(7);
+        } catch (Exception e) {
+            throw new UnauthorizedAccessException();
+        }
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/controller/LabTestController.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/controller/LabTestController.java
@@ -1,0 +1,33 @@
+package org.teamseven.hms.backend.booking.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.teamseven.hms.backend.booking.annotation.LabTestStatusUpdateAccessValidated;
+import org.teamseven.hms.backend.booking.dto.UpdateLabTestRequest;
+import org.teamseven.hms.backend.booking.service.LabTestService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/tests")
+public class LabTestController {
+    @Autowired private LabTestService labTestService;
+
+    @LabTestStatusUpdateAccessValidated
+    @PatchMapping("/{testId}")
+    public ResponseEntity updateLabTest(
+            @RequestBody UpdateLabTestRequest updateLabTestRequest,
+            @PathVariable UUID testId
+    ) {
+        boolean isUpdateSuccesful = labTestService.updateTestStatus(
+                testId,
+                updateLabTestRequest.getStatus()
+        );
+
+        return ResponseEntity
+                .status(isUpdateSuccesful? HttpStatus.NO_CONTENT : HttpStatus.NOT_MODIFIED)
+                .build();
+    }
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/controller/LabTestController.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/controller/LabTestController.java
@@ -1,5 +1,6 @@
 package org.teamseven.hms.backend.booking.controller;
 
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +16,15 @@ import java.util.UUID;
 public class LabTestController {
     @Autowired private LabTestService labTestService;
 
-    @LabTestStatusUpdateAccessValidated
+//    @LabTestStatusUpdateAccessValidated
     @PatchMapping("/{testId}")
     public ResponseEntity updateLabTest(
-            @RequestBody UpdateLabTestRequest updateLabTestRequest,
+            @Valid @RequestBody UpdateLabTestRequest updateLabTestRequest,
             @PathVariable UUID testId
     ) {
         boolean isUpdateSuccesful = labTestService.updateTestStatus(
                 testId,
+                updateLabTestRequest.getResult(),
                 updateLabTestRequest.getStatus()
         );
 

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateLabTestRequest.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateLabTestRequest.java
@@ -1,5 +1,6 @@
 package org.teamseven.hms.backend.booking.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,5 +12,6 @@ import org.teamseven.hms.backend.booking.entity.TestStatus;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UpdateLabTestRequest {
-    private TestStatus status;
+    @NotNull private TestStatus status;
+    @NotNull private String result;
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateLabTestRequest.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateLabTestRequest.java
@@ -13,5 +13,5 @@ import org.teamseven.hms.backend.booking.entity.TestStatus;
 @NoArgsConstructor
 public class UpdateLabTestRequest {
     @NotNull private TestStatus status;
-    @NotNull private String result;
+    private String result;
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateLabTestRequest.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/UpdateLabTestRequest.java
@@ -1,0 +1,15 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.teamseven.hms.backend.booking.entity.TestStatus;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateLabTestRequest {
+    private TestStatus status;
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/TestRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/TestRepository.java
@@ -12,8 +12,9 @@ public interface TestRepository extends CrudRepository<Test, UUID> {
     @Modifying(clearAutomatically = true)
     @Query(
             "update Test t set " +
-                    "t.status = :status " +
+                    "t.status = :status, " +
+                    "t.testReport = :result " +
                     "where t.testId = :testId"
     )
-    int setTestStatus(TestStatus status, UUID testId);
+    int setTestStatus(TestStatus status, String result, UUID testId);
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/TestRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/TestRepository.java
@@ -1,8 +1,19 @@
 package org.teamseven.hms.backend.booking.entity;
 
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.UUID;
 
 public interface TestRepository extends CrudRepository<Test, UUID> {
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(
+            "update Test t set " +
+                    "t.status = :status " +
+                    "where t.testId = :testId"
+    )
+    int setTestStatus(TestStatus status, UUID testId);
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/service/LabTestService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/LabTestService.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public class LabTestService {
     @Autowired private TestRepository testRepository;
 
-    public boolean updateTestStatus(UUID testId, TestStatus newStatus) {
-        return testRepository.setTestStatus(newStatus, testId) == 1;
+    public boolean updateTestStatus(UUID testId, String result, TestStatus newStatus) {
+        return testRepository.setTestStatus(newStatus, result,  testId) == 1;
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/service/LabTestService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/LabTestService.java
@@ -1,0 +1,17 @@
+package org.teamseven.hms.backend.booking.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.teamseven.hms.backend.booking.entity.TestRepository;
+import org.teamseven.hms.backend.booking.entity.TestStatus;
+
+import java.util.UUID;
+
+@Service
+public class LabTestService {
+    @Autowired private TestRepository testRepository;
+
+    public boolean updateTestStatus(UUID testId, TestStatus newStatus) {
+        return testRepository.setTestStatus(newStatus, testId) == 1;
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAccessAspectTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAccessAspectTest.java
@@ -1,0 +1,99 @@
+package org.teamseven.hms.backend.booking.annotation;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.teamseven.hms.backend.config.JwtService;
+import org.teamseven.hms.backend.shared.exception.UnauthorizedAccessException;
+import org.teamseven.hms.backend.user.Role;
+
+import java.security.Key;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LabTestStatusUpdateAccessAspectTest {
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    LabTestStatusUpdateAspect aspect;
+
+    @BeforeEach
+    public void setUp() {
+        Mockito.reset(jwtService);
+    }
+
+    @Test
+    public void testValidateAccessAllowed_userIsLabSupportStaff_assertNotThrowUnauthorized() {
+        ProceedingJoinPoint proceedingJoinPoint = mock();
+        LabTestStatusUpdateAccessValidated mockAnnotation = mock();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        request.addHeader("Authorization", "Bearer mock token");
+
+        when(jwtService.extractAllClaims(any()))
+                .thenReturn(
+                        getMockClaims(Role.LAB_SUPPORT_STAFF, UUID.randomUUID().toString())
+                );
+
+        assertDoesNotThrow(
+                () -> { aspect.validateAccessAllowed(proceedingJoinPoint, mockAnnotation); }
+        );
+    }
+
+    @Test
+    public void testValidateAccessAllowed_userIsNotLabStaff_assertThrowUnauthorized() {
+        ProceedingJoinPoint proceedingJoinPoint = mock();
+        LabTestStatusUpdateAccessValidated mockAnnotation = mock();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        request.addHeader("Authorization", "Bearer mock token");
+
+        when(jwtService.extractAllClaims(any()))
+                .thenReturn(
+                        getMockClaims(Role.DOCTOR, UUID.randomUUID().toString())
+                );
+
+        assertThrows(
+                UnauthorizedAccessException.class,
+                () -> { aspect.validateAccessAllowed(proceedingJoinPoint, mockAnnotation); }
+        );
+    }
+
+    private Claims getMockClaims(
+            Role role,
+            String roleId
+    ) {
+        byte[] randomKeyBytes = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".getBytes();
+        Key mockKey = Keys.hmacShaKeyFor(randomKeyBytes);
+        String jwt = Jwts.builder()
+                .setClaims(Map.of("ROLE", role, "roleId", roleId))
+                .signWith(mockKey, SignatureAlgorithm.HS256)
+                .compact();
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(mockKey)
+                .build()
+                .parseClaimsJws(jwt)
+                .getBody();
+    }
+}

--- a/src/test/java/org/teamseven/hms/backend/booking/controller/LabTestControllerTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/controller/LabTestControllerTest.java
@@ -14,7 +14,10 @@ import org.teamseven.hms.backend.booking.dto.UpdateLabTestRequest;
 import org.teamseven.hms.backend.booking.entity.TestStatus;
 import org.teamseven.hms.backend.booking.service.LabTestService;
 
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,27 +41,35 @@ public class LabTestControllerTest {
 
     @Test
     public void testUpdateTestStatus_successfulUpdate_assertReturn204() throws Exception{
-        UpdateLabTestRequest request = new UpdateLabTestRequest(TestStatus.PENDING);
+        UpdateLabTestRequest request = new UpdateLabTestRequest(TestStatus.PENDING, "test result");
 
-        when(service.updateTestStatus(any(), any())).thenReturn(true);
+        when(service.updateTestStatus(any(), any(), any())).thenReturn(true);
 
         mockMvc.perform(
                 patch("/api/v1/tests/07fec0a8-7145-11ee-8684-0242ac130003")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         ).andExpect(status().isNoContent());
+
+        verify(service).updateTestStatus(
+                UUID.fromString("07fec0a8-7145-11ee-8684-0242ac130003"), "test result", TestStatus.PENDING
+        );
     }
 
     @Test
     public void testUpdateAppointment_unsuccessfulUpdate_assertReturn304() throws Exception{
-        UpdateLabTestRequest request = new UpdateLabTestRequest(TestStatus.PENDING);
+        UpdateLabTestRequest request = new UpdateLabTestRequest(TestStatus.PENDING, "test result");
 
-        when(service.updateTestStatus(any(), any())).thenReturn(false);
+        when(service.updateTestStatus(any(), any(), any())).thenReturn(false);
 
         mockMvc.perform(
                 patch("/api/v1/tests/07fec0a8-7145-11ee-8684-0242ac130003")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         ).andExpect(status().isNotModified());
+
+        verify(service).updateTestStatus(
+                UUID.fromString("07fec0a8-7145-11ee-8684-0242ac130003"), "test result", TestStatus.PENDING
+        );
     }
 }

--- a/src/test/java/org/teamseven/hms/backend/booking/controller/LabTestControllerTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/controller/LabTestControllerTest.java
@@ -1,0 +1,64 @@
+package org.teamseven.hms.backend.booking.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.teamseven.hms.backend.booking.dto.UpdateLabTestRequest;
+import org.teamseven.hms.backend.booking.entity.TestStatus;
+import org.teamseven.hms.backend.booking.service.LabTestService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class LabTestControllerTest {
+    @Mock
+    private LabTestService service;
+
+    @InjectMocks
+    private LabTestController controller;
+
+    private MockMvc mockMvc;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        this.mockMvc =  MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    public void testUpdateTestStatus_successfulUpdate_assertReturn204() throws Exception{
+        UpdateLabTestRequest request = new UpdateLabTestRequest(TestStatus.PENDING);
+
+        when(service.updateTestStatus(any(), any())).thenReturn(true);
+
+        mockMvc.perform(
+                patch("/api/v1/tests/07fec0a8-7145-11ee-8684-0242ac130003")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        ).andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void testUpdateAppointment_unsuccessfulUpdate_assertReturn304() throws Exception{
+        UpdateLabTestRequest request = new UpdateLabTestRequest(TestStatus.PENDING);
+
+        when(service.updateTestStatus(any(), any())).thenReturn(false);
+
+        mockMvc.perform(
+                patch("/api/v1/tests/07fec0a8-7145-11ee-8684-0242ac130003")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        ).andExpect(status().isNotModified());
+    }
+}


### PR DESCRIPTION
- Changes on this PR add a new endpoint to allow updates of test result & status.
- This endpoint is accessible provided that the role of the logged in user is a `LAB_SUPPORT_STAFF`
- It's expected for the request body to always contain the result & status. null updates are possible for result