### PR TITLE
Allow doctor to see upcoming appointments

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/DoctorAppointmentEndpointAccessAspect.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/DoctorAppointmentEndpointAccessAspect.java
@@ -16,15 +16,15 @@ import org.teamseven.hms.backend.user.Role;
 
 @Aspect
 @Component
-public class AppointmentUpdateAccessAspect {
+public class DoctorAppointmentEndpointAccessAspect {
     @Autowired
     private JwtService jwtService;
 
     @VisibleForTesting
-    @Around("@annotation(appointmentUpdateAccessValidated)")
+    @Around("@annotation(doctorAppointmentEndpointAccessValidated)")
     protected Object validateAccessAllowed(
             ProceedingJoinPoint pjp,
-            AppointmentUpdateAccessValidated appointmentUpdateAccessValidated
+            DoctorAppointmentEndpointAccessValidated doctorAppointmentEndpointAccessValidated
     ) throws Throwable{
         HttpServletRequest request = (
                 (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()

--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/DoctorAppointmentEndpointAccessValidated.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/DoctorAppointmentEndpointAccessValidated.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AppointmentUpdateAccessValidated {
+public @interface DoctorAppointmentEndpointAccessValidated {
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/controller/AppointmentController.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/controller/AppointmentController.java
@@ -1,23 +1,26 @@
 package org.teamseven.hms.backend.booking.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
 import org.springframework.web.bind.annotation.*;
-import org.teamseven.hms.backend.booking.annotation.AppointmentUpdateAccessValidated;
+import org.teamseven.hms.backend.booking.annotation.DoctorAppointmentEndpointAccessValidated;
 import org.teamseven.hms.backend.booking.dto.UpdateAppointmentRequest;
 import org.teamseven.hms.backend.booking.service.AppointmentService;
+import org.teamseven.hms.backend.shared.ResponseWrapper;
 
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/v1/appointments/")
+@RequestMapping("/api/v1/appointments")
 public class AppointmentController {
     @Autowired
     private AppointmentService appointmentService;
 
-    @AppointmentUpdateAccessValidated
-    @PatchMapping("{appointmentId}")
+    @DoctorAppointmentEndpointAccessValidated
+    @PatchMapping("/{appointmentId}")
     public ResponseEntity updateAppointments(
             @RequestBody UpdateAppointmentRequest updateAppointmentRequest,
             @PathVariable UUID appointmentId
@@ -30,5 +33,19 @@ public class AppointmentController {
         return ResponseEntity
                 .status(isUpdateSuccesful? HttpStatus.NO_CONTENT : HttpStatus.NOT_MODIFIED)
                 .build();
+    }
+
+    @DoctorAppointmentEndpointAccessValidated
+    @GetMapping
+    public ResponseEntity<ResponseWrapper> getDoctorAppointments(
+            @NonNull HttpServletRequest request,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        return ResponseEntity.ok(
+                new ResponseWrapper.Success(
+                        appointmentService.getDoctorSlots(request, page, pageSize)
+                )
+        );
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/AppointmentBookingSlotItem.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/AppointmentBookingSlotItem.java
@@ -1,0 +1,20 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.teamseven.hms.backend.booking.entity.AppointmentStatus;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppointmentBookingSlotItem {
+    private String patientName;
+    private AppointmentStatus status;
+    private String reservedDate;
+    private UUID bookingId;
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/AppointmentBookingSlotPaginationResponse.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/AppointmentBookingSlotPaginationResponse.java
@@ -1,0 +1,20 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppointmentBookingSlotPaginationResponse {
+    private long totalElements;
+    private int currentPage;
+
+    private List<AppointmentBookingSlotItem> items;
+}
+

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
@@ -57,4 +57,17 @@ public interface BookingRepository extends CrudRepository<Booking, UUID> {
     @Modifying(clearAutomatically = true)
     @Query(value = "update bookings set bill_status = :billStatus, paid_at = :paidAt where booking_id = UUID_TO_BIN(:bookingId)", nativeQuery = true)
     int updateBillStatus(String billStatus, String paidAt, String bookingId);
+
+    @Query(
+            value = "SELECT * " +
+                    "from bookings where service_id = UUID_TO_BIN(:serviceId) " +
+                    "AND reserved_date >= :reservedDate " +
+                    "ORDER BY reserved_date, created_at",
+            nativeQuery=true
+    )
+    Page<Booking> findUpcomingServiceBookings(
+            String serviceId,
+            String reservedDate,
+            Pageable pageable
+    );
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/TestStatus.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/TestStatus.java
@@ -2,5 +2,7 @@ package org.teamseven.hms.backend.booking.entity;
 
 public enum TestStatus {
     PENDING,
+
+    PENDING_RESULT,
     COMPLETED
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/service/AppointmentService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/AppointmentService.java
@@ -1,15 +1,34 @@
 package org.teamseven.hms.backend.booking.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.teamseven.hms.backend.booking.dto.AppointmentBookingSlotItem;
+import org.teamseven.hms.backend.booking.dto.AppointmentBookingSlotPaginationResponse;
 import org.teamseven.hms.backend.booking.dto.UpdateAppointmentRequest;
 import org.teamseven.hms.backend.booking.entity.AppointmentRepository;
-
+import org.teamseven.hms.backend.booking.entity.Booking;
+import org.teamseven.hms.backend.catalog.dto.ServiceOverview;
+import org.teamseven.hms.backend.catalog.service.CatalogService;
+import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
+import org.teamseven.hms.backend.user.service.PatientService;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class AppointmentService {
     @Autowired private AppointmentRepository repository;
+
+    @Autowired private PatientService patientService;
+
+    @Autowired private BookingService bookingService;
+
+    @Autowired private CatalogService catalogService;
 
     public boolean updateAppointmentDetails(
             UUID appointmentId,
@@ -20,5 +39,39 @@ public class AppointmentService {
                 appointmentRequest.getComments(),
                 appointmentId
         ) == 1;
+    }
+
+    public AppointmentBookingSlotPaginationResponse getDoctorSlots(
+            HttpServletRequest request,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        UUID doctorId = UUID.fromString(request.getAttribute("roleId").toString());
+        ServiceOverview overview = catalogService.getServiceOverviewByDoctorId(doctorId);
+        int zeroBasedIdxPage = page - 1;
+
+        Page<Booking> bookingPage = bookingService.findUpcomingServiceBookings(
+                overview.getServiceId(),
+                Pageable.ofSize(pageSize).withPage(zeroBasedIdxPage)
+        );
+
+        List<UUID> patientIdList = bookingPage.getContent().stream().map(Booking::getPatientId).toList();
+
+        Map<UUID, PatientProfileOverview> patientProfiles = patientService.getByUUIDs(
+                patientIdList
+        ).stream().collect(Collectors.toMap(PatientProfileOverview::getPatientId, item -> item));
+
+        return AppointmentBookingSlotPaginationResponse
+                .builder()
+                .currentPage(page)
+                .totalElements(bookingPage.getTotalElements())
+                .items(bookingPage.stream().map(it ->
+                        AppointmentBookingSlotItem.builder()
+                                .bookingId(it.getBookingId())
+                                .patientName(patientProfiles.get(it.getPatientId()).getPatientName())
+                                .status(it.getAppointment().getStatus())
+                                .reservedDate(it.getReservedDate())
+                                .build()
+                ).toList()).build();
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/service/BookingService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/BookingService.java
@@ -14,6 +14,7 @@ import org.teamseven.hms.backend.user.entity.Patient;
 import org.teamseven.hms.backend.user.entity.PatientRepository;
 import org.teamseven.hms.backend.user.service.PatientService;
 
+import java.time.LocalDate;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.function.BiFunction;
@@ -230,5 +231,13 @@ public class BookingService {
     private boolean bookingExists(String date, String slot) {
         Optional<Booking> booking = bookingRepository.findByAppointmentDate(date, slot);
         return booking.isPresent();
+    }
+
+    public Page<Booking> findUpcomingServiceBookings(UUID serviceId, Pageable pageable) {
+        return bookingRepository.findUpcomingServiceBookings(
+                serviceId.toString(),
+                LocalDate.now().toString(),
+                pageable
+        );
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/catalog/entity/ServiceRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/entity/ServiceRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ServiceRepository extends CrudRepository<Service, UUID> {
@@ -20,4 +21,6 @@ public interface ServiceRepository extends CrudRepository<Service, UUID> {
             @Param("serviceType") String serviceType,
             Pageable pageable
     );
+
+    Optional<Service> findByDoctorId(UUID doctorId);
 }

--- a/src/main/java/org/teamseven/hms/backend/catalog/service/CatalogService.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/service/CatalogService.java
@@ -107,4 +107,11 @@ public class CatalogService {
             .specialty(profile.getSpecialty())
             .yearsOfExperience(profile.getYearOfExperience())
             .type(ServiceType.APPOINTMENT).build();
+
+    public ServiceOverview getServiceOverviewByDoctorId(UUID doctorId) {
+        org.teamseven.hms.backend.catalog.entity.Service service = repository.findByDoctorId(doctorId)
+                .orElseThrow(NoSuchElementException::new);
+
+        return getOverview.apply(service);
+    }
 }

--- a/src/main/java/org/teamseven/hms/backend/config/SecurityConfiguration.java
+++ b/src/main/java/org/teamseven/hms/backend/config/SecurityConfiguration.java
@@ -22,7 +22,10 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 @EnableMethodSecurity
 @EnableConfigurationProperties(SecurityEnvConfig.class)
 public class SecurityConfiguration {
-    private static final String[] WHITE_LIST_URL = {"/api/v1/auth/**"};
+    private static final String[] WHITE_LIST_URL = {
+            "/api/v1/auth/**",
+            "/api/v1/available-services/*"
+    };
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final AuthenticationProvider authenticationProvider;
     private final SecurityEnvConfig envConfig;

--- a/src/main/java/org/teamseven/hms/backend/user/dto/PatientProfileOverview.java
+++ b/src/main/java/org/teamseven/hms/backend/user/dto/PatientProfileOverview.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
+import java.util.UUID;
 
 @Data
 @Builder
@@ -16,4 +17,5 @@ public class PatientProfileOverview {
     private String patientName;
     private String gender;
     private String dateOfBirth;
+    private UUID patientId;
 }

--- a/src/main/java/org/teamseven/hms/backend/user/service/PatientService.java
+++ b/src/main/java/org/teamseven/hms/backend/user/service/PatientService.java
@@ -1,5 +1,6 @@
 package org.teamseven.hms.backend.user.service;
 
+import org.assertj.core.util.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.teamseven.hms.backend.user.User;
@@ -7,6 +8,7 @@ import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
 import org.teamseven.hms.backend.user.entity.Patient;
 import org.teamseven.hms.backend.user.entity.PatientRepository;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
@@ -19,10 +21,21 @@ public class PatientService {
     public PatientProfileOverview getPatientProfile(UUID patientId) {
         Patient patient = repository.findById(patientId).orElseThrow(NoSuchElementException::new);
         User user = patient.getUser();
+        return getOverview(user, patientId);
+    }
+
+    public List<PatientProfileOverview> getByUUIDs(List<UUID> patientIds) {
+        List<Patient> patients = Lists.newArrayList(repository.findAllById(patientIds));
+
+        return patients.stream().map(it -> getOverview(it.getUser(), it.getPatientId())).toList();
+    }
+
+    private PatientProfileOverview getOverview(User user, UUID patient) {
         return PatientProfileOverview.builder()
                 .patientName(user.getName())
                 .gender(user.getGender())
                 .dateOfBirth(user.getDateOfBirth())
+                .patientId(patient)
                 .build();
     }
 }

--- a/src/test/java/org/teamseven/hms/backend/booking/annotation/DoctorAppointmentEndpointAspectTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/annotation/DoctorAppointmentEndpointAspectTest.java
@@ -30,12 +30,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class AppointmentUpdateAspectTest {
+public class DoctorAppointmentEndpointAspectTest {
     @Mock
     private JwtService jwtService;
 
     @InjectMocks
-    AppointmentUpdateAccessAspect aspect;
+    DoctorAppointmentEndpointAccessAspect aspect;
 
     @BeforeEach
     public void setUp() {
@@ -45,7 +45,7 @@ public class AppointmentUpdateAspectTest {
     @Test
     public void testValidateAccessAllowed_userIsDoctor_assertNotThrowUnauthorized() {
         ProceedingJoinPoint proceedingJoinPoint = mock();
-        AppointmentUpdateAccessValidated mockAnnotation = mock();
+        DoctorAppointmentEndpointAccessValidated mockAnnotation = mock();
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
         request.addHeader("Authorization", "Bearer mock token");
@@ -63,7 +63,7 @@ public class AppointmentUpdateAspectTest {
     @Test
     public void testValidateAccessAllowed_userIsNotDoctor_assertThrowUnauthorized() {
         ProceedingJoinPoint proceedingJoinPoint = mock();
-        AppointmentUpdateAccessValidated mockAnnotation = mock();
+        DoctorAppointmentEndpointAccessValidated mockAnnotation = mock();
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
         request.addHeader("Authorization", "Bearer mock token");

--- a/src/test/java/org/teamseven/hms/backend/booking/controller/AppointmentControllerTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/controller/AppointmentControllerTest.java
@@ -10,12 +10,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.teamseven.hms.backend.booking.dto.AppointmentBookingSlotItem;
+import org.teamseven.hms.backend.booking.dto.AppointmentBookingSlotPaginationResponse;
 import org.teamseven.hms.backend.booking.dto.UpdateAppointmentRequest;
 import org.teamseven.hms.backend.booking.entity.AppointmentStatus;
 import org.teamseven.hms.backend.booking.service.AppointmentService;
 
+import java.util.List;
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -66,5 +73,32 @@ public class AppointmentControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         ).andExpect(status().isNotModified());
+    }
+
+    @Test
+    public void testGetAppointmentSlots_assertReturnList_andReturn200() throws Exception{
+        AppointmentBookingSlotPaginationResponse mockResponse = AppointmentBookingSlotPaginationResponse
+                .builder()
+                .items(
+                        List.of(
+                                AppointmentBookingSlotItem.builder()
+                                        .bookingId(UUID.randomUUID())
+                                        .patientName("Jane Doe")
+                                        .status(AppointmentStatus.COMPLETED)
+                                        .reservedDate("2023-10-10")
+                                        .build()
+                        )
+                )
+                .totalElements(1)
+                .currentPage(1)
+                .build();
+
+        when(service.getDoctorSlots(any(), anyInt(), anyInt())).thenReturn(mockResponse);
+
+        mockMvc.perform(
+                get("/api/v1/appointments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(mockResponse))
+        ).andExpect(status().isOk());
     }
 }

--- a/src/test/java/org/teamseven/hms/backend/booking/service/AppointmentServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/service/AppointmentServiceTest.java
@@ -1,0 +1,97 @@
+package org.teamseven.hms.backend.booking.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.teamseven.hms.backend.booking.entity.Appointment;
+import org.teamseven.hms.backend.booking.entity.AppointmentStatus;
+import org.teamseven.hms.backend.booking.entity.Booking;
+import org.teamseven.hms.backend.catalog.dto.ServiceOverview;
+import org.teamseven.hms.backend.catalog.service.CatalogService;
+import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
+import org.teamseven.hms.backend.user.service.PatientService;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AppointmentServiceTest {
+    @Mock
+    private CatalogService catalogService;
+
+    @Mock
+    private BookingService bookingService;
+
+    @Mock
+    private PatientService patientService;
+
+    @InjectMocks
+    private AppointmentService appointmentService;
+
+    @Test
+    public void getDoctorSlots_appointmentsExist_returnAppointmentInfo() throws Exception{
+        HttpServletRequest request = mock();
+
+        when(request.getAttribute("roleId")).thenReturn("00b063be-5002-40a8-9073-54026c0615b2");
+
+        UUID mockServiceId = UUID.fromString("5cd46763-5869-4dec-bec6-588c55398bff");
+        when(catalogService.getServiceOverviewByDoctorId(any()))
+                .thenReturn(
+                        ServiceOverview.builder().serviceId(mockServiceId).build()
+                );
+
+        when(bookingService.findUpcomingServiceBookings(any(), any()))
+                .thenReturn(
+                        new PageImpl(
+                                getMockBookingList(),
+                                PageRequest.of(0, 10),
+                                1L
+                        )
+                );
+
+        when(patientService.getByUUIDs(any())).thenReturn(
+                List.of(
+                        PatientProfileOverview.builder()
+                                .patientName("test name")
+                                .patientId(UUID.fromString("8a61e51b-7930-4549-b273-a9143abde3e3"))
+                                .build()
+                )
+        );
+
+        appointmentService.getDoctorSlots(request, 1, 10);
+        verify(catalogService).getServiceOverviewByDoctorId(UUID.fromString("00b063be-5002-40a8-9073-54026c0615b2"));
+        verify(bookingService).findUpcomingServiceBookings(eq(mockServiceId), any());
+        verify(patientService).getByUUIDs(List.of(UUID.fromString("8a61e51b-7930-4549-b273-a9143abde3e3")));
+    }
+
+    private List<Booking> getMockBookingList() throws ParseException {
+        return List.of(getAppointmentBooking());
+    }
+
+    private Booking getAppointmentBooking() throws ParseException {
+        return Booking.builder()
+                .appointment(
+                        Appointment.builder()
+                                .status(AppointmentStatus.PENDING)
+                                .diagnosis("test").
+                                appointmentId(UUID.randomUUID())
+                                .build()
+                )
+                .slots("1")
+                .patientId(UUID.fromString("8a61e51b-7930-4549-b273-a9143abde3e3"))
+                .bookingId(UUID.fromString("efb5f4bf-75e3-49a5-8785-bb82b70029ed"))
+                .serviceId(UUID.fromString("c4dcd184-ae0b-4cd9-bd91-22ff4ce71321"))
+                .reservedDate("2023-12-11")
+                .build();
+    }
+
+}


### PR DESCRIPTION
## Feature / Problem
- Add the endpoint GET `/api/v1/appointments` to allow doctors to see the list of upcoming appointments that they have.
- Modify PatientProfileOverview to return patient id for bulk querying patient data
- add enum PENDING_RESULT to Test Status