### PR TITLE
Allow support staff to view upcoming test appointments

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestEndpointAccessValidated.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestEndpointAccessValidated.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface LabTestStatusUpdateAccessValidated {
+public @interface LabTestEndpointAccessValidated {
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAspect.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/LabTestStatusUpdateAspect.java
@@ -14,18 +14,16 @@ import org.teamseven.hms.backend.config.JwtService;
 import org.teamseven.hms.backend.shared.exception.UnauthorizedAccessException;
 import org.teamseven.hms.backend.user.Role;
 
-import java.util.logging.Logger;
-
 @Aspect
 @Component
 public class LabTestStatusUpdateAspect {
     @Autowired private JwtService jwtService;
 
     @VisibleForTesting
-    @Around("@annotation(labTestUpdateAccessValidated)")
+    @Around("@annotation(labTestEndpointAccessValidated)")
     protected Object validateAccessAllowed(
             ProceedingJoinPoint pjp,
-            LabTestStatusUpdateAccessValidated labTestUpdateAccessValidated
+            LabTestEndpointAccessValidated labTestEndpointAccessValidated
     ) throws Throwable {
         HttpServletRequest request = (
                 (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()

--- a/src/main/java/org/teamseven/hms/backend/booking/controller/LabTestController.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/controller/LabTestController.java
@@ -5,9 +5,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.teamseven.hms.backend.booking.annotation.LabTestStatusUpdateAccessValidated;
+import org.teamseven.hms.backend.booking.annotation.LabTestEndpointAccessValidated;
 import org.teamseven.hms.backend.booking.dto.UpdateLabTestRequest;
 import org.teamseven.hms.backend.booking.service.LabTestService;
+import org.teamseven.hms.backend.shared.ResponseWrapper;
 
 import java.util.UUID;
 
@@ -16,7 +17,7 @@ import java.util.UUID;
 public class LabTestController {
     @Autowired private LabTestService labTestService;
 
-//    @LabTestStatusUpdateAccessValidated
+    @LabTestEndpointAccessValidated
     @PatchMapping("/{testId}")
     public ResponseEntity updateLabTest(
             @Valid @RequestBody UpdateLabTestRequest updateLabTestRequest,
@@ -31,5 +32,19 @@ public class LabTestController {
         return ResponseEntity
                 .status(isUpdateSuccesful? HttpStatus.NO_CONTENT : HttpStatus.NOT_MODIFIED)
                 .build();
+    }
+
+
+    @LabTestEndpointAccessValidated
+    @GetMapping
+    public ResponseEntity<ResponseWrapper> getTestAppointments(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        return ResponseEntity.ok(
+                new ResponseWrapper.Success(
+                        labTestService.getTestAppointments(page, pageSize)
+                )
+        );
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/TestAppointmentSlotItem.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/TestAppointmentSlotItem.java
@@ -1,0 +1,21 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.teamseven.hms.backend.booking.entity.TestStatus;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TestAppointmentSlotItem {
+    private String patientName;
+    private TestStatus status;
+    private String testName;
+    private String reservedDate;
+    private UUID bookingId;
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/dto/TestAppointmentSlotPaginationResponse.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/dto/TestAppointmentSlotPaginationResponse.java
@@ -1,0 +1,19 @@
+package org.teamseven.hms.backend.booking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TestAppointmentSlotPaginationResponse {
+    private long totalElements;
+    private int currentPage;
+
+    private List<TestAppointmentSlotItem> items;
+}

--- a/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/entity/BookingRepository.java
@@ -60,6 +60,18 @@ public interface BookingRepository extends CrudRepository<Booking, UUID> {
 
     @Query(
             value = "SELECT * " +
+                    "from bookings where test_id IS NOT NULL " +
+                    "AND reserved_date >= :reservedDate " +
+                    "ORDER BY reserved_date, created_at",
+            nativeQuery=true
+    )
+    Page<Booking> findUpcomingTestBookings(
+            String reservedDate,
+            Pageable pageable
+    );
+
+    @Query(
+            value = "SELECT * " +
                     "from bookings where service_id = UUID_TO_BIN(:serviceId) " +
                     "AND reserved_date >= :reservedDate " +
                     "ORDER BY reserved_date, created_at",

--- a/src/main/java/org/teamseven/hms/backend/booking/service/BookingService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/BookingService.java
@@ -159,6 +159,7 @@ public class BookingService {
 
     @Transactional
     public Booking reserveSlot(AddBookingRequest bookingRequest) {
+        ServiceOverview serviceOverview = catalogService.getServiceOverview(bookingRequest.getServiceId());
         Booking booked = new Booking();
         if (Objects.equals(bookingRequest.getType(), BookingType.APPOINTMENT)) {
             if(bookingExists(bookingRequest.getAppointmentDate(), bookingRequest.getSelectedSlot())) {
@@ -177,6 +178,7 @@ public class BookingService {
             var test = Test.builder()
                     .patientId(bookingRequest.getPatientId())
                     .testDate(bookingRequest.getAppointmentDate())
+                    .testName(serviceOverview.getName())
                     .status(TestStatus.PENDING)
                     .isActive(true)
                     .build();
@@ -231,6 +233,13 @@ public class BookingService {
     private boolean bookingExists(String date, String slot) {
         Optional<Booking> booking = bookingRepository.findByAppointmentDate(date, slot);
         return booking.isPresent();
+    }
+
+    public Page<Booking> findUpcomingTestBookings(Pageable pageable) {
+        return bookingRepository.findUpcomingTestBookings(
+                LocalDate.now().toString(),
+                pageable
+        );
     }
 
     public Page<Booking> findUpcomingServiceBookings(UUID serviceId, Pageable pageable) {

--- a/src/main/java/org/teamseven/hms/backend/booking/service/LabTestService.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/service/LabTestService.java
@@ -1,17 +1,58 @@
 package org.teamseven.hms.backend.booking.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.teamseven.hms.backend.booking.dto.TestAppointmentSlotItem;
+import org.teamseven.hms.backend.booking.dto.TestAppointmentSlotPaginationResponse;
+import org.teamseven.hms.backend.booking.entity.Booking;
 import org.teamseven.hms.backend.booking.entity.TestRepository;
 import org.teamseven.hms.backend.booking.entity.TestStatus;
+import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
+import org.teamseven.hms.backend.user.service.PatientService;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class LabTestService {
     @Autowired private TestRepository testRepository;
 
+    @Autowired private BookingService bookingService;
+
+    @Autowired private PatientService patientService;
+
     public boolean updateTestStatus(UUID testId, String result, TestStatus newStatus) {
         return testRepository.setTestStatus(newStatus, result,  testId) == 1;
+    }
+
+    public TestAppointmentSlotPaginationResponse getTestAppointments(int page, int pageSize) {
+        int zeroBasedIdxPage = page - 1;
+        Page<Booking> bookings = bookingService.findUpcomingTestBookings(
+                Pageable.ofSize(pageSize).withPage(zeroBasedIdxPage)
+        );
+
+        List<UUID> patientIdList = bookings.getContent().stream().map(Booking::getPatientId).toList();
+
+        Map<UUID, PatientProfileOverview> patientProfiles = patientService.getByUUIDs(
+                patientIdList
+        ).stream().collect(Collectors.toMap(PatientProfileOverview::getPatientId, item -> item));
+
+        return TestAppointmentSlotPaginationResponse
+                .builder()
+                .currentPage(page)
+                .totalElements(bookings.getTotalElements())
+                .items(bookings.stream().map(it ->
+                        TestAppointmentSlotItem.builder()
+                                .bookingId(it.getBookingId())
+                                .patientName(patientProfiles.get(it.getPatientId()).getPatientName())
+                                .status(it.getTest().getStatus())
+                                .testName(it.getTest().getTestName())
+                                .reservedDate(it.getReservedDate())
+                                .build()
+                ).toList()).build();
     }
 }

--- a/src/test/java/org/teamseven/hms/backend/booking/annotation/LabTestEndpointAccessAspectTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/annotation/LabTestEndpointAccessAspectTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class LabTestStatusUpdateAccessAspectTest {
+public class LabTestEndpointAccessAspectTest {
     @Mock
     private JwtService jwtService;
 
@@ -45,7 +45,7 @@ public class LabTestStatusUpdateAccessAspectTest {
     @Test
     public void testValidateAccessAllowed_userIsLabSupportStaff_assertNotThrowUnauthorized() {
         ProceedingJoinPoint proceedingJoinPoint = mock();
-        LabTestStatusUpdateAccessValidated mockAnnotation = mock();
+        LabTestEndpointAccessValidated mockAnnotation = mock();
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
         request.addHeader("Authorization", "Bearer mock token");
@@ -63,7 +63,7 @@ public class LabTestStatusUpdateAccessAspectTest {
     @Test
     public void testValidateAccessAllowed_userIsNotLabStaff_assertThrowUnauthorized() {
         ProceedingJoinPoint proceedingJoinPoint = mock();
-        LabTestStatusUpdateAccessValidated mockAnnotation = mock();
+        LabTestEndpointAccessValidated mockAnnotation = mock();
         MockHttpServletRequest request = new MockHttpServletRequest();
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
         request.addHeader("Authorization", "Bearer mock token");

--- a/src/test/java/org/teamseven/hms/backend/booking/controller/LabTestControllerTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/controller/LabTestControllerTest.java
@@ -10,15 +10,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.teamseven.hms.backend.booking.dto.TestAppointmentSlotItem;
+import org.teamseven.hms.backend.booking.dto.TestAppointmentSlotPaginationResponse;
 import org.teamseven.hms.backend.booking.dto.UpdateLabTestRequest;
 import org.teamseven.hms.backend.booking.entity.TestStatus;
 import org.teamseven.hms.backend.booking.service.LabTestService;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -71,5 +76,35 @@ public class LabTestControllerTest {
         verify(service).updateTestStatus(
                 UUID.fromString("07fec0a8-7145-11ee-8684-0242ac130003"), "test result", TestStatus.PENDING
         );
+    }
+
+    @Test
+    public void testGetTestSlots_assertReturnList_andReturn200() throws Exception{
+        TestAppointmentSlotPaginationResponse mockResponse = TestAppointmentSlotPaginationResponse
+                .builder()
+                .items(
+                        List.of(
+                                TestAppointmentSlotItem.builder()
+                                        .bookingId(UUID.randomUUID())
+                                        .patientName("Jane Doe")
+                                        .status(TestStatus.COMPLETED)
+                                        .testName("test name")
+                                        .reservedDate("2023-10-10")
+                                        .build()
+                        )
+                )
+                .totalElements(1)
+                .currentPage(1)
+                .build();
+
+        when(service.getTestAppointments(anyInt(), anyInt())).thenReturn(mockResponse);
+
+        mockMvc.perform(
+                get("/api/v1/tests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(mockResponse))
+        ).andExpect(status().isOk());
+
+        verify(service).getTestAppointments(1, 10);
     }
 }

--- a/src/test/java/org/teamseven/hms/backend/booking/service/LabTestServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/booking/service/LabTestServiceTest.java
@@ -1,0 +1,79 @@
+package org.teamseven.hms.backend.booking.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.teamseven.hms.backend.booking.entity.Booking;
+import org.teamseven.hms.backend.booking.entity.TestRepository;
+import org.teamseven.hms.backend.booking.entity.TestStatus;
+import org.teamseven.hms.backend.user.dto.PatientProfileOverview;
+import org.teamseven.hms.backend.user.service.PatientService;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LabTestServiceTest {
+    @Mock
+    private TestRepository testRepository;
+
+    @Mock
+    private BookingService bookingService;
+
+    @Mock
+    private PatientService patientService;
+
+    @InjectMocks
+    private LabTestService labTestService;
+
+    @Test
+    public void testGetTestAppointments_givenFoundTests_returnList() throws ParseException {
+        when(bookingService.findUpcomingTestBookings(any()))
+                .thenReturn(
+                        new PageImpl(
+                                getMockBookingList(),
+                                PageRequest.of(0, 10),
+                                1L
+                        )
+                );
+
+        when(patientService.getByUUIDs(any())).thenReturn(
+                List.of(
+                        PatientProfileOverview.builder()
+                                .patientName("test name")
+                                .patientId(UUID.fromString("8a61e51b-7930-4549-b273-a9143abde3e3"))
+                                .build()
+                )
+        );
+
+        labTestService.getTestAppointments(1, 10);
+        verify(bookingService).findUpcomingTestBookings(any());
+        verify(patientService).getByUUIDs(List.of(UUID.fromString("8a61e51b-7930-4549-b273-a9143abde3e3")));
+    }
+
+    private List<Booking> getMockBookingList() throws ParseException {
+        return List.of(
+                Booking.builder()
+                        .test(
+                                org.teamseven.hms.backend.booking.entity.Test.builder()
+                                        .status(TestStatus.PENDING)
+                                                .testName("test name")
+                                        .build()
+                        )
+                        .patientId(UUID.fromString("8a61e51b-7930-4549-b273-a9143abde3e3"))
+                        .bookingId(UUID.fromString("efb5f4bf-75e3-49a5-8785-bb82b70029ed"))
+                        .serviceId(UUID.fromString("c4dcd184-ae0b-4cd9-bd91-22ff4ce71321"))
+                        .reservedDate("2023-12-11")
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
- Changes add a new endpoint `GET /api/v1/tests`.
- Endpoint is made only accessible to lab support staff
- Changes are also done to create booking endpoint to populate test-name on tests table, in favor of reducing the coupling between booking domain & catalog domain for fetching bookings functionality