### PR TITLE
Display pricing in service overview

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/controller/BookingController.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/controller/BookingController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.teamseven.hms.backend.booking.annotation.PatientBookingAccessValidated;
+import org.teamseven.hms.backend.booking.annotation.PatientDataRequestedMethod;
 import org.teamseven.hms.backend.booking.dto.AddBookingRequest;
 import org.teamseven.hms.backend.booking.service.BookingService;
 import org.teamseven.hms.backend.booking.service.SlotCheckerService;
@@ -41,7 +42,7 @@ public class BookingController {
     }
 
 
-    @PatientBookingAccessValidated
+    @PatientBookingAccessValidated(dataRequestMethod = PatientDataRequestedMethod.BOOKING_ID_PATH)
     @GetMapping(value = "bookings/{bookingId}")
     public ResponseEntity<ResponseWrapper> getBookingDetails(
             @PathVariable UUID bookingId

--- a/src/main/java/org/teamseven/hms/backend/catalog/dto/ServiceCatalogItem.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/dto/ServiceCatalogItem.java
@@ -18,6 +18,7 @@ public sealed class ServiceCatalogItem {
         private String description;
         private UUID serviceId;
         private ServiceType type = ServiceType.TEST;
+        private Double estimatedPrice;
     }
 
     @Data
@@ -32,5 +33,6 @@ public sealed class ServiceCatalogItem {
         private UUID doctorId;
         private String yearsOfExperience;
         private String specialty;
+        private Double estimatedPrice;
     }
 }

--- a/src/main/java/org/teamseven/hms/backend/catalog/service/CatalogService.java
+++ b/src/main/java/org/teamseven/hms/backend/catalog/service/CatalogService.java
@@ -80,6 +80,7 @@ public class CatalogService {
             .description(it.getDescription())
             .serviceId(UUID.fromString(it.getServiceid()))
             .type(ServiceType.TEST)
+            .estimatedPrice(it.getEstimatedPrice())
             .build();
 
     private List<ServiceCatalogItem> constructDoctorAppointmentsCatalog(
@@ -117,6 +118,7 @@ public class CatalogService {
             .description(it.getDescription())
             .specialty(profile.getSpecialty())
             .yearsOfExperience(profile.getYearOfExperience())
+            .estimatedPrice(it.getEstimatedPrice())
             .type(ServiceType.APPOINTMENT).build();
 
     public ServiceOverview getServiceOverviewByDoctorId(UUID doctorId) {

--- a/src/test/java/org/teamseven/hms/backend/catalog/service/CatalogServiceTest.java
+++ b/src/test/java/org/teamseven/hms/backend/catalog/service/CatalogServiceTest.java
@@ -130,6 +130,7 @@ public class CatalogServiceTest {
                         .serviceid(UUID.randomUUID().toString())
                         .name("test name")
                         .description("test description")
+                        .estimatedPrice(25.5)
                         .build()
         );
     }
@@ -141,6 +142,7 @@ public class CatalogServiceTest {
                         .serviceid(UUID.randomUUID().toString())
                         .name("test name")
                         .description("test description")
+                        .estimatedPrice(25.5)
                         .build()
         );
     }


### PR DESCRIPTION
- Earlier we didn't return estimated charges on service catalog endpoints.
- It turns out that we display the estimated charges on booking modal.
- In order to provide sufficient info on that, we need to get the estimated charges based on the service estimated price (populated when a doctor is enrolled into the system).