### PR TITLE
Modify build runner

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
 
-    runs-on: StagingRunner
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- We've noticed that the image build github action has been behaving inconsistently.
- after checking, it seems like the self-hosted runner may not be as consistent as the standard github runner.
- Changes on this PR are raised as part of an attempt to debug and/or work around the issue to make sure the latest image is always built