### PR TITLE
Work around null role id for authorization check on booking data

### DIFF
--- a/src/main/java/org/teamseven/hms/backend/booking/annotation/PatientBookingAccessAspect.java
+++ b/src/main/java/org/teamseven/hms/backend/booking/annotation/PatientBookingAccessAspect.java
@@ -33,8 +33,6 @@ public class PatientBookingAccessAspect {
         ).getRequest();
         String jwtToken = getJwtToken(request);
         Claims jwtClaims = jwtService.extractAllClaims(jwtToken);
-
-        UUID roleIdentifier = UUID.fromString(jwtClaims.get("roleId", String.class));
         Role role = Role.valueOf(jwtClaims.get("ROLE", String.class));
 
         switch (role) {
@@ -42,6 +40,12 @@ public class PatientBookingAccessAspect {
                 PatientDataRequestedMethod dataRequestMethod = patientBookingAccessValidated.dataRequestMethod();
                 BookingEndpointPatientAccessValidator validator = BookingEndpointPatientAccessValidator
                         .getValidator(dataRequestMethod);
+
+                if (jwtClaims.get("roleId", String.class) == null) {
+                    throw new UnauthorizedAccessException();
+                }
+
+                UUID roleIdentifier = UUID.fromString(jwtClaims.get("roleId", String.class));
 
                 if (!validator.isAccessGranted(pjp, roleIdentifier)) {
                     throw new UnauthorizedAccessException();


### PR DESCRIPTION
- Seeing booking details when the logged in user is a lab support staff yields an invalid UUID error.
- After checking, this is due to `roleId` being null inside the JWT token for lab support staff.
- The endpoint authorization checks against the roleId - hence throwing an error when encountering null role ids.
- As a result, only checks role id in jwt token if the person sending a request is a patient