### PR TITLE
Exclude data classes from jacoco configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Naming convention is as follows
 {U|V}{version_num}__{description_may_be_separated_by_underscores}.sql
 ```
 
+## Running unit tests
+To run unit tests & coverage report, execute the command below.
+```
+./mvnw [clean] test
+```
+Automatically generates code coverage based on the tests created. This excludes `dto/` and `entity/` from coverage calculation since all classes within said packages are dumb classes.
+Find coverage report inside `target/site/jacoco/index.html`
+
 ## Running the application
 To run, use the following command:
 ```agsl

--- a/pom.xml
+++ b/pom.xml
@@ -98,17 +98,6 @@
       <version>2.2.220</version>
     </dependency>
     <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>jacoco-maven-plugin</artifactId>
-      <version>0.8.10</version>
-      <exclusions>
-        <exclusion>  <!-- declare the exclusion here -->
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.24.2</version>
@@ -201,6 +190,11 @@
               <artifactId>junit</artifactId>
             </exclusion>
           </exclusions>
+            <excludes>
+                <exclude>org/teamseven/hms/backend/*/dto/*</exclude>
+                <exclude>org/teamseven/hms/backend/*/entity/*</exclude>
+                <exclude>**/config/*</exclude>
+            </excludes>
         </configuration>
         <executions>
           <execution>
@@ -219,7 +213,6 @@
         </executions>
       </plugin>
     </plugins>
-
   </build>
 
 </project>


### PR DESCRIPTION
- In order to show more accurate code coverage data, exclude data classes from jacoco report. classes scanned are shown as the following jacoco report
<img width="1224" alt="image" src="https://github.com/PracticeProjectGroup7/Backend/assets/36232939/a529f0a0-9cb0-40d2-a322-fce38cbe2b56">
